### PR TITLE
Use other table for RefCountedBlobs

### DIFF
--- a/bsstore/proto/schema.proto
+++ b/bsstore/proto/schema.proto
@@ -13,7 +13,7 @@ message RefCountedBlob {
 }
 
 message BlobView {
-  RefCountedBlob rcBlob = 1;
+  exoscale.sos.Blob blob = 1; // Blob reference
   int64 blobOffset = 2; // Offset into the referenced Blob
   int64 blobSize = 3; // Size to consider from the offset
   int64 extentOffset = 4;
@@ -31,7 +31,7 @@ message Extent {
  * top level message in an union.
  */
 message RecordTypeUnion {
-  // RefCountedBlob _RefCountedBlob = 1; // nested
-  // BlobView       _BlobView       = 2; // nested
+  RefCountedBlob _RefCountedBlob = 1;
+  // BlobView       _BlobView       = 2; // nested inside Extent
   Extent         _Extent         = 3;
 }

--- a/bsstore/src/exoscale/blockstorage/bsstore.clj
+++ b/bsstore/src/exoscale/blockstorage/bsstore.clj
@@ -22,7 +22,12 @@
 
 ;; First we define primary keys and indices for the metastore
 (def ^:private schema
-  {:Extent
+  {:RefCountedBlob
+   {:primary-key [:concat :type-key
+                  [:nested "blob" "partition"]
+                  [:nested "blob" "blob_id"]]}
+
+   :Extent
    {:primary-key [:concat :type-key
                   "uuid"
                   "diskOffset"]
@@ -127,4 +132,3 @@
                           :schema       schema})))
 
 (s/def ::bsstore (partial satisfies? bs/AtomicMetastore))
-


### PR DESCRIPTION
The RefCountedBlob can't be nested, otherwise we would not be able to have multiple references on it. I only updated the proto + schema, so this fix would break the code behind.

Note: Having RefCountedBlob inside of BlobView might be possible, this is how it's done in SOS from what i recall